### PR TITLE
Fix to select right datatype if DECIMAL_DIGITS for a column is less than 0 for a oracle database.

### DIFF
--- a/src/main/java/com/amazon/carbonado/repo/jdbc/JDBCStorableIntrospector.java
+++ b/src/main/java/com/amazon/carbonado/repo/jdbc/JDBCStorableIntrospector.java
@@ -754,14 +754,14 @@ public class JDBCStorableIntrospector extends StorableIntrospector {
         case NUMERIC:
         case DECIMAL:
             if (desiredClass == int.class) {
-                if (decimalDigits == 0) {
+                if (decimalDigits <= 0) {
                     actualClass = int.class;
                     suffix = "Int";
                 } else {
                     return null;
                 }
             } else if (desiredClass == long.class) {
-                if (decimalDigits == 0) {
+                if (decimalDigits <= 0) {
                     actualClass = long.class;
                     suffix = "Long";
                 } else {
@@ -774,14 +774,14 @@ public class JDBCStorableIntrospector extends StorableIntrospector {
                 actualClass = BigDecimal.class;
                 suffix = "BigDecimal";
             } else if (desiredClass == short.class) {
-                if (decimalDigits == 0) {
+                if (decimalDigits <= 0) {
                     actualClass = short.class;
                     suffix = "Short";
                 } else {
                     return null;
                 }
             } else if (desiredClass == byte.class) {
-                if (decimalDigits == 0) {
+                if (decimalDigits <= 0) {
                     actualClass = byte.class;
                     suffix = "Byte";
                 } else {


### PR DESCRIPTION
Since 11.2 release of Oracle JDBC Driver, it started to return DECIMAL_DIGITS as a negative number for various numeric datatypes.
These changes would make Carbonado compatible with these new version of jdbc to use right datatypes.
