### PR TITLE
Fix OFFSET without LIMIT for H2 Database

### DIFF
--- a/src/main/java/com/amazon/carbonado/repo/jdbc/H2SupportStrategy.java
+++ b/src/main/java/com/amazon/carbonado/repo/jdbc/H2SupportStrategy.java
@@ -53,7 +53,7 @@ class H2SupportStrategy extends JDBCSupportStrategy {
                 return select.concat(" LIMIT ?");
             }
         } else if (from) {
-            return select.concat(" LIMIT 2147483647 OFFSET ?");
+            return select.concat(" OFFSET ?");
         } else {
             return select;
         }


### PR DESCRIPTION
Carbonado used LIMIT 2^32+1 as a kludge to allow OFFSET without LIMIT
in H2 Database, but this approach no longer works. As of version 1.4.191
Beta (2016-01-21), H2 supports OFFSET without LIMIT natively, so use
that instead.